### PR TITLE
Fix mobile window dragging on fortytwo.html

### DIFF
--- a/assets/js/fortytwo.js
+++ b/assets/js/fortytwo.js
@@ -438,6 +438,7 @@ class GameTableWindowManager {
             this.bringWindowToFront(window);
         });
         
+        // Mouse events for desktop
         header.addEventListener('mousedown', (e) => {
             if (e.target === header || header.contains(e.target)) {
                 isDragging = true;
@@ -446,6 +447,19 @@ class GameTableWindowManager {
                 // Update initial position based on current mouse position and window offset
                 initialX = e.clientX - xOffset;
                 initialY = e.clientY - yOffset;
+            }
+        });
+        
+        // Touch events for mobile
+        header.addEventListener('touchstart', (e) => {
+            if (e.target === header || header.contains(e.target)) {
+                isDragging = true;
+                this.bringWindowToFront(window);
+                
+                // Get the first touch
+                const touch = e.touches[0];
+                initialX = touch.clientX - xOffset;
+                initialY = touch.clientY - yOffset;
             }
         });
         
@@ -462,11 +476,35 @@ class GameTableWindowManager {
             }
         });
         
+        document.addEventListener('touchmove', (e) => {
+            if (isDragging) {
+                e.preventDefault();
+                
+                // Get the first touch
+                const touch = e.touches[0];
+                currentX = touch.clientX - initialX;
+                currentY = touch.clientY - initialY;
+                xOffset = currentX;
+                yOffset = currentY;
+                
+                window.style.left = `${currentX}px`;
+                window.style.top = `${currentY}px`;
+            }
+        });
+        
         document.addEventListener('mouseup', () => {
             if (isDragging) {
-            initialX = currentX;
-            initialY = currentY;
-            isDragging = false;
+                initialX = currentX;
+                initialY = currentY;
+                isDragging = false;
+            }
+        });
+        
+        document.addEventListener('touchend', () => {
+            if (isDragging) {
+                initialX = currentX;
+                initialY = currentY;
+                isDragging = false;
             }
         });
     }

--- a/pages/index norm.html
+++ b/pages/index norm.html
@@ -20,6 +20,8 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
+    <!-- jQuery UI Touch Punch - enables touch support for draggable -->
+    <script src="https://cdn.jsdelivr.net/npm/jquery-ui-touch-punch@0.2.3/jquery.ui.touch-punch.min.js"></script>
     <script
       type="text/javascript"
       src="libraries/p5.js"

--- a/pages/mosscomposites.html
+++ b/pages/mosscomposites.html
@@ -19,6 +19,8 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
+    <!-- jQuery UI Touch Punch - enables touch support for draggable -->
+    <script src="https://cdn.jsdelivr.net/npm/jquery-ui-touch-punch@0.2.3/jquery.ui.touch-punch.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../style.css" />
   <!--Favicon-->
     <link


### PR DESCRIPTION
Enable draggable windows on mobile devices across all relevant pages.

The custom `makeDraggable` implementation in `fortytwo.js` was updated to include touch event listeners (`touchstart`, `touchmove`, `touchend`). Additionally, the `jQuery UI Touch Punch` library was added to `pages/index norm.html` and `pages/mosscomposites.html` to provide touch support for their jQuery UI draggable elements. This ensures consistent draggable functionality on both desktop and mobile.