### PR TITLE
Fix mobile bid submission bug

### DIFF
--- a/assets/css/fortytwo.css
+++ b/assets/css/fortytwo.css
@@ -1285,6 +1285,8 @@ body {
         color: lime !important;
         text-align: center !important;
         margin-bottom: 10px !important;
+        touch-action: manipulation !important; /* Optimize for mobile touch */
+        -webkit-appearance: none !important; /* Remove iOS styling */
     }
     
     .player-bid-input:focus {

--- a/assets/js/fortytwo.js
+++ b/assets/js/fortytwo.js
@@ -673,7 +673,10 @@ class GameTableWindowManager {
         
         // Touch event handlers for mobile
         window.addEventListener('touchstart', (e) => {
-            e.preventDefault();
+            // Only prevent default if not touching an interactive element
+            if (!e.target.closest('button, input, select, textarea, .interactive-element')) {
+                e.preventDefault();
+            }
             isDragging = true;
             this.bringWindowToFront(window);
             
@@ -1127,6 +1130,16 @@ class GameTableWindowManager {
         const bidInput = document.getElementById(`player-bid-input-${playerIndex}`);
         if (bidInput) {
             bidInput.style.display = 'block';
+            
+            // Focus the input field after a short delay to ensure it's visible
+            setTimeout(() => {
+                const inputField = document.getElementById(`player-bid-input-field-${playerIndex}`);
+                if (inputField) {
+                    inputField.focus();
+                    // On mobile, also ensure the input is scrolled into view
+                    inputField.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+            }, 100);
         }
     }
     
@@ -1262,6 +1275,17 @@ class GameTableWindowManager {
                 if (e.key === 'Enter') {
                     handleBidSubmit();
                 }
+            });
+            
+            // Add mobile-specific input field event handling
+            bidInputField.addEventListener('touchstart', (e) => {
+                // Ensure the input field can receive focus on mobile
+                e.stopPropagation();
+            });
+            
+            bidInputField.addEventListener('focus', (e) => {
+                // Ensure the input stays focused and visible on mobile
+                e.target.scrollIntoView({ behavior: 'smooth', block: 'center' });
             });
         }
         
@@ -4246,7 +4270,10 @@ class Game {
         
         // Touch event handlers for mobile
         window.addEventListener('touchstart', (e) => {
-            e.preventDefault();
+            // Only prevent default if not touching an interactive element
+            if (!e.target.closest('button, input, select, textarea, .interactive-element')) {
+                e.preventDefault();
+            }
             isDragging = true;
             this.bringWindowToFront(window);
             


### PR DESCRIPTION
Fix mobile bid input field inaccessibility by preventing `e.preventDefault()` on interactive elements and enhancing mobile touch support.

The existing `touchstart` event handlers for draggable windows were calling `e.preventDefault()` unconditionally, which blocked all touch interactions (including focusing input fields) on mobile devices. This PR modifies these handlers to only prevent default for non-interactive elements, allowing proper interaction with the bid input field. Additional CSS and JS enhancements improve the overall mobile experience for the input.