### PR TITLE
Adjust Trump selection buttons for mobile

### DIFF
--- a/assets/css/fortytwo.css
+++ b/assets/css/fortytwo.css
@@ -1238,4 +1238,74 @@ body {
         position: relative;
         z-index: 10;
     }
+    
+    /* Trump selection buttons mobile optimization */
+    .player-trump-selection-area {
+        padding: 12px !important;
+    }
+    
+    .player-trump-selector {
+        gap: 8px !important;
+        margin-bottom: 12px !important;
+    }
+    
+    .player-trump-option {
+        padding: 8px 12px !important;
+        font-size: 14px !important;
+        min-width: 44px;
+        min-height: 44px;
+        touch-action: manipulation;
+        -webkit-tap-highlight-color: rgba(0,0,0,0.1);
+        position: relative;
+        z-index: 10;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    
+    .player-trump-option:active {
+        transform: scale(0.95);
+        opacity: 0.8;
+    }
+    
+    .player-confirm-trump-btn {
+        padding: 8px 16px !important;
+        font-size: 14px !important;
+        min-width: 44px;
+        min-height: 44px;
+        touch-action: manipulation;
+        -webkit-tap-highlight-color: rgba(0,0,0,0.1);
+        position: relative;
+        z-index: 10;
+    }
+    
+    .player-confirm-trump-btn:active {
+        transform: scale(0.95);
+        opacity: 0.8;
+    }
+    
+    /* General trump selector mobile optimization */
+    .trump-selector {
+        margin: 15px 0 !important;
+    }
+    
+    .trump-option {
+        padding: 8px 12px !important;
+        margin: 4px !important;
+        font-size: 14px !important;
+        min-width: 44px;
+        min-height: 44px;
+        touch-action: manipulation;
+        -webkit-tap-highlight-color: rgba(0,0,0,0.1);
+        position: relative;
+        z-index: 10;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+    
+    .trump-option:active {
+        transform: scale(0.95);
+        opacity: 0.8;
+    }
 }


### PR DESCRIPTION
Optimize Trump selection buttons for mobile devices to improve usability and touch interaction.

Previously, these buttons had very small padding (3px/6px) and font size (10px) on mobile, making them difficult to tap. This PR increases their size to meet mobile accessibility standards (44px min-width/height) and improves touch handling.